### PR TITLE
[IMP] auth_oidc: Mute expected error logger during tests

### DIFF
--- a/auth_oidc/__manifest__.py
+++ b/auth_oidc/__manifest__.py
@@ -9,7 +9,8 @@
     "author": (
         "ICTSTUDIO, André Schenkels, "
         "ACSONE SA/NV, "
-        "Odoo Community Association (OCA)"
+        "Odoo Community Association (OCA), "
+        "Odoo PS"
     ),
     "maintainers": ["sbidoul"],
     "website": "https://github.com/OCA/server-auth",

--- a/auth_oidc/tests/test_auth_oidc_auth_code.py
+++ b/auth_oidc/tests/test_auth_oidc_auth_code.py
@@ -15,6 +15,7 @@ from jose.utils import long_to_base64
 import odoo
 from odoo.exceptions import AccessDenied
 from odoo.tests import common
+from odoo.tools.misc import mute_logger
 
 from odoo.addons.website.tools import MockRequest as _MockRequest
 
@@ -251,7 +252,10 @@ class TestAuthOIDCAuthorizationCodeFlow(common.HttpCase):
         )
 
         with self.assertRaises(AccessDenied):
-            with MockRequest(self.env):
+            with (
+                MockRequest(self.env),
+                mute_logger("odoo.addons.auth_oidc.models.res_users"),
+            ):
                 self.env["res.users"].auth_oauth(
                     self.provider_rec.id,
                     {"state": json.dumps({})},


### PR DESCRIPTION
Unit test `TestAuthOIDCAuthorizationCodeFlow.test_login_without_any_key` expects an error to be raised but the underlying method calls `_logger.error` as well, therefore printing an error line in the logs which triggers runbot and Odoo SH builds to fail (but the test is successful).

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [x] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit